### PR TITLE
fix/He/mergeEval

### DIFF
--- a/src/assert_mod.F90
+++ b/src/assert_mod.F90
@@ -643,7 +643,11 @@ contains
     logical :: passed
     real(4) :: eps_
 
-    eps_ = merge(eps, eps_default_kind4, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind4
+    end if
 
     if (x == y) then
       passed = .true.
@@ -669,7 +673,11 @@ contains
     logical :: passed
     real(8) :: eps_
 
-    eps_ = merge(eps, eps_default_kind8, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind8
+    end if
 
     if (x == y) then
       passed = .true.
@@ -697,7 +705,11 @@ contains
     integer :: loc, i
     real(4) :: eps_
 
-    eps_ = merge(eps, eps_default_kind4, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind4
+    end if
 
     loc = lbound(x, 1)
     passed = .true.
@@ -746,7 +758,11 @@ contains
     integer :: loc, i
     real(8) :: eps_
 
-    eps_ = merge(eps, eps_default_kind8, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind8
+    end if
 
     loc = lbound(x, 1)
     passed = .true.
@@ -815,7 +831,11 @@ contains
     integer :: loc_i, loc_j, i, j
     real(4) :: eps_
 
-    eps_ = merge(eps, eps_default_kind4, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind4
+    end if
 
     loc_i = min(lbound(x, 1), lbound(y, 1))
     loc_j = min(lbound(x, 2), lbound(y, 2))
@@ -890,7 +910,11 @@ contains
     integer :: loc_i, loc_j, i, j
     real(8) :: eps_
 
-    eps_ = merge(eps, eps_default_kind8, present(eps))
+    if (present(eps)) then
+      eps_ = eps
+    else
+      eps_ = eps_default_kind8
+    end if
 
     loc_i = min(lbound(x, 1), lbound(y, 1))
     loc_j = min(lbound(x, 2), lbound(y, 2))
@@ -1463,7 +1487,15 @@ contains
     real(4), intent(in) :: y
     integer, optional, intent(in) :: case
 
-    select case (merge(case, 1, present(case)))
+    integer :: case_
+
+    if (present(case)) then
+      case_ = case
+    else
+      case_ = 1
+    end if
+    
+    select case (case_)
 
     case (1)
       get_relative_difference_real4 = abs(max(abs(x), abs(y)))
@@ -1493,7 +1525,15 @@ contains
     real(8), intent(in) :: y
     integer, optional, intent(in) :: case
 
-    select case (merge(case, 1, present(case)))
+    integer :: case_
+
+    if (present(case)) then
+      case_ = case
+    else
+      case_ = 1
+    end if
+
+    select case (case_)
 
     case (1)
       get_relative_difference_real8 = abs(max(abs(x), abs(y)))


### PR DESCRIPTION
merge can evaluate all its arguments. The behavior is not specified in the standard. To avoid undefined behavior this is fixed

https://fortran-lang.discourse.group/t/is-there-another-function-in-fortran-like-merge-that-does-not-evaluate-its-arguments/7414/6